### PR TITLE
fix: rename analize_doc → analyze_doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ ENTITY_TYPES_TO_SKIP_CEFR = {
 
 doc = nlp(text)
 text_analyzer = CEFRSpaCyAnalyzer(entity_types_to_skip=ENTITY_TYPES_TO_SKIP_CEFR, abbreviation_mapping=ABBREVIATION_MAPPING)
-tokens = text_analyzer.analize_doc(doc)
+tokens = text_analyzer.analyze_doc(doc)
 
 print('-' * 55)
 print(f' {"WORD".ljust(26)}\tPOS\tLEVEL\tCEFR')

--- a/docs/docs.md
+++ b/docs/docs.md
@@ -123,7 +123,7 @@ ENTITY_TYPES_TO_SKIP_CEFR = {
 
 doc = nlp(text)
 text_analyzer = CEFRSpaCyAnalyzer(entity_types_to_skip=ENTITY_TYPES_TO_SKIP_CEFR, abbreviation_mapping=ABBREVIATION_MAPPING)
-tokens = text_analyzer.analize_doc(doc)
+tokens = text_analyzer.analyze_doc(doc)
 
 print('-' * 55)
 print(f' {"WORD".ljust(26)}\tPOS\tLEVEL\tCEFR')

--- a/src/cefrpy/CEFRSpaCyAnalyzer.py
+++ b/src/cefrpy/CEFRSpaCyAnalyzer.py
@@ -67,7 +67,7 @@ class CEFRSpaCyAnalyzer():
 
         return result_dict
 
-    def analize_doc(self, doc) -> list[tuple[str, str, bool, float, int, int]]:
+    def analyze_doc(self, doc) -> list[tuple[str, str, bool, float, int, int]]:
         """
         Analyze the document for CEFR levels, considering skipped entities and abbreviation mapping.
 


### PR DESCRIPTION
Fixes #3

## Changes
- Renamed `analize_doc` to `analyze_doc` in `CEFRSpaCyAnalyzer.py` (method definition)
- Updated usage in `README.md` and `docs/docs.md`

## Scope
3 files, 3 lines changed. No functional changes, no test references affected.